### PR TITLE
fix: fix bug with differential times in dt.cc

### DIFF
--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -1378,10 +1378,11 @@ class HypoDDRelocator(object):
                     continue
                 # Otherwise calculate the corrected differential travel time.
                 diff_travel_time = (
-                    pick_2["pick_time"]
+                    (pick_1["pick_time"]
+                    - event_1_dict["origin_time"]) -
+                    (pick_2["pick_time"]
                     + pick2_corr
-                    - event_2_dict["origin_time"]
-                ) - (pick_1["pick_time"] - event_1_dict["origin_time"])
+                    - event_2_dict["origin_time"]))
                 string = "{station_id} {travel_time:.6f} {weight:.4f} {phase}"
                 string = string.format(
                     station_id=pick_1["station_id"],


### PR DESCRIPTION
This fixes the bug with the differential travel times in dt.cc (issue #7) by reversing the terms of the subtraction.

BREAKING CHANGE
Originally, differential times for events 1 and 2 were defined as T2-T1 (after correcting T2 with waveform alignment), while the hypoDD manual defines them as T1-T2