### PR TITLE
Issue 22 preferred origin

### DIFF
--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -534,8 +534,8 @@ class HypoDDRelocator(object):
                 current_event["magnitude"] = event.preferred_magnitude().mag
             else:
                 current_event["magnitude"] = 0.0
-            # Always take the first origin.
-            origin = event.origins[0]
+            # Always take the preferred origin.
+            origin = event.preferred_origin()
             current_event["origin_time"] = origin.time
             # Origin time error.
             if origin.time_errors.uncertainty is not None:


### PR DESCRIPTION
It selects the preferred origin of each event prepared as  hypoDD input. The default behavior was to assume that each event only has one origin. Events with only one origin are not affected by this commit. The method _create_plots() had to be slightly modified    so as to not break the plot creation.